### PR TITLE
Hotfix: Check EVM address in universal swap

### DIFF
--- a/src/pages/UniversalSwap/Swap/index.tsx
+++ b/src/pages/UniversalSwap/Swap/index.tsx
@@ -23,7 +23,7 @@ import { RootState } from 'store/configure';
 import SelectTokenModalV2 from '../Modals/SelectTokenModalV2';
 import { TooltipIcon } from '../Modals/SettingTooltip';
 import SlippageModal from '../Modals/SlippageModal';
-import { UniversalSwapHandler } from '../helpers';
+import { UniversalSwapHandler, checkEvmAddress } from '../helpers';
 import styles from './index.module.scss';
 
 const cx = cn.bind(styles);
@@ -143,8 +143,10 @@ const SwapComponent: React.FC<{
       const univeralSwapHandler = new UniversalSwapHandler(oraiAddress, originalFromToken, originalToToken, fromAmountToken, simulateData.amount, userSlippage);
       const toAddress = await univeralSwapHandler.getUniversalSwapToAddress(originalToToken.chainId);
       const { combinedReceiver, universalSwapType } = combineReceiver(oraiAddress, originalFromToken, originalToToken, toAddress);
-      console.log({ toAddress, combinedReceiver, universalSwapType })
-      const result = await univeralSwapHandler.processUniversalSwap(combinedReceiver, universalSwapType, { metamaskAddress: window.Metamask.toCheckSumEthAddress(metamaskAddress), tronAddress });
+      checkEvmAddress(originalFromToken.chainId, metamaskAddress, tronAddress);
+      checkEvmAddress(originalToToken.chainId, metamaskAddress, tronAddress);
+      const checksumMetamaskAddress = window.Metamask.toCheckSumEthAddress(metamaskAddress)
+      const result = await univeralSwapHandler.processUniversalSwap(combinedReceiver, universalSwapType, { metamaskAddress: checksumMetamaskAddress, tronAddress });
       if (result) {
         displayToast(TToastType.TX_SUCCESSFUL, {
           customLink: getTransactionUrl(originalFromToken.chainId, result.transactionHash)

--- a/src/pages/UniversalSwap/helpers.ts
+++ b/src/pages/UniversalSwap/helpers.ts
@@ -27,6 +27,21 @@ const evmChainIds = chainInfos
   .filter((chain) => chain.networkType === 'evm' && chain.chainId !== '0x1ae6')
   .map((t) => t.chainId);
 
+export const checkEvmAddress = (chainId: NetworkChainId, metamaskAddress?: string, tronAddress?: string | boolean) => {
+  switch (chainId) {
+    case '0x01':
+    case '0x38':
+      if (!metamaskAddress) {
+        throw generateError('Please login Metamask wallet!');
+      }
+      break;
+    case '0x2b6653dc':
+      if (!tronAddress) {
+        throw generateError('Please login Tron wallet!');
+      }
+  }
+};
+
 export class UniversalSwapHandler {
   private _sender: string;
   private _fromToken: TokenItemType;

--- a/src/tests/universal-swap.spec.ts
+++ b/src/tests/universal-swap.spec.ts
@@ -17,7 +17,7 @@ import { toAmount, toDisplay, toTokenInfo } from 'libs/utils';
 import Long from 'long';
 import { combineReceiver, findToToken, getDestination } from 'pages/BalanceNew/helpers';
 import { calculateMinReceive } from 'pages/SwapV2/helpers';
-import { UniversalSwapHandler } from 'pages/UniversalSwap/helpers';
+import { UniversalSwapHandler, checkEvmAddress } from 'pages/UniversalSwap/helpers';
 import { Type, generateContractMessages, simulateSwap } from 'rest/api';
 import * as restApi from 'rest/api';
 import { IBCInfo } from 'types/ibc';
@@ -904,4 +904,38 @@ describe('universal-swap', () => {
       expect(ibcMemo).toEqual(expectedIbcMemo);
     }
   );
+
+  describe('checkEvmAddress', () => {
+    const testCases = [
+      ['0x01', '', undefined],
+      ['0x38', '', undefined],
+      ['0x2b6653dc', undefined, '']
+    ];
+    it.each(testCases)(
+      'throws an error when not logged in to wallet (%s)',
+      (chainId: NetworkChainId, metamaskAddress?: string, tronAddress?: string | boolean) => {
+        expect(() => {
+          checkEvmAddress(chainId, metamaskAddress, tronAddress);
+        }).toThrow();
+      }
+    );
+
+    it('does not throw an error when logged in to Metamask on Ethereum', () => {
+      expect(() => {
+        checkEvmAddress('0x01', '0x1234abcd');
+      }).not.toThrow();
+    });
+
+    it('does not throw an error when logged in to Metamask on BSC', () => {
+      expect(() => {
+        checkEvmAddress('0x38', '0x5678efgh');
+      }).not.toThrow();
+    });
+
+    it('does not throw an error when logged in to Tron wallet', () => {
+      expect(() => {
+        checkEvmAddress('0x2b6653dc', '', 'TRON_ADDRESS');
+      }).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
What is the purpose of the changes?

  - Fix error pass empty EVM address to toChecksumAddress
  
Brief changelog:

  - Add function & testcase to validate EVM address in Universal swap
  
Documentation and Release Note

  - Does this PR introduces new features or user-facing behaviour changes? No
  - How is the feature or changes documented? No