### PR TITLE
hot fix simulate display amount universal swap

### DIFF
--- a/src/pages/UniversalSwap/Swap/hooks/useSimulate.ts
+++ b/src/pages/UniversalSwap/Swap/hooks/useSimulate.ts
@@ -37,10 +37,7 @@ export const useSimulate = (
   );
 
   useEffect(() => {
-    setSwapAmount([
-      fromAmountToken,
-      toDisplay(simulateData?.displayAmount, originalToTokenInfo?.decimals, toTokenInfoData?.decimals)
-    ]);
+    setSwapAmount([fromAmountToken, Number(simulateData?.displayAmount)]);
   }, [simulateData, fromAmountToken, fromTokenInfoData, toTokenInfoData]);
 
   return { simulateData, fromAmountToken, toAmountToken, setSwapAmount };

--- a/src/pages/UniversalSwap/Swap/index.tsx
+++ b/src/pages/UniversalSwap/Swap/index.tsx
@@ -206,7 +206,7 @@ const SwapComponent: React.FC<{
       );
       const toAddress = await univeralSwapHandler.getUniversalSwapToAddress(originalToToken.chainId, {
         metamaskAddress,
-        tronAddress,
+        tronAddress
       });
       const { combinedReceiver, universalSwapType } = combineReceiver(
         oraiAddress,
@@ -248,7 +248,7 @@ const SwapComponent: React.FC<{
   // );
 
   // minimum receive after slippage
-  const minimumReceive = simulateData?.displayAmount ? calculateMinimum(simulateData.displayAmount, userSlippage) : '0';
+  const minimumReceive = simulateData?.displayAmount ? calculateMinimum(simulateData.displayAmount, userSlippage) : 0;
 
   return (
     <LoadingBox loading={loadingRefresh}>
@@ -340,9 +340,7 @@ const SwapComponent: React.FC<{
             />
 
             <span style={{ flexGrow: 1, textAlign: 'right' }}>
-              {`1 ${originalFromToken?.name} ≈ ${toDisplay(averageRatio?.displayAmount, originalToToken?.decimals)} ${
-                originalToToken?.name
-              }`}
+              {`1 ${originalFromToken?.name} ≈ ${averageRatio?.displayAmount} ${originalToToken?.name}`}
             </span>
           </div>
           <div className={cx('input-wrapper')}>
@@ -387,9 +385,7 @@ const SwapComponent: React.FC<{
             </div>
             <TokenBalance
               balance={{
-                amount: toDisplay(minimumReceive, originalToToken?.decimals, toTokenInfoData?.decimals).toFixed(
-                  truncDecimals
-                ),
+                amount: minimumReceive.toFixed(truncDecimals),
                 denom: toTokenInfoData?.symbol
               }}
               decimalScale={truncDecimals}

--- a/src/pages/UniversalSwap/helpers.ts
+++ b/src/pages/UniversalSwap/helpers.ts
@@ -47,7 +47,7 @@ export enum SwapDirection {
 
 export interface SimulateResponse {
   amount: Uint128;
-  displayAmount: Uint128;
+  displayAmount: number;
 }
 
 export interface SwapData {
@@ -71,15 +71,16 @@ export const getTransferTokenFee = async ({ remoteTokenDenom }): Promise<Ratio |
   }
 };
 
-export const calculateMinimum = (simulateAmount: number | string, userSlippage: number): bigint | string => {
-  if (!simulateAmount) return '0';
+export const calculateMinimum = (simulateAmountDisplay: number | string, userSlippage: number): number => {
+  if (!simulateAmountDisplay) return 0;
   try {
     const result =
-      BigInt(simulateAmount) - (BigInt(simulateAmount) * BigInt(userSlippage * atomic)) / (100n * BigInt(atomic));
+      Number(simulateAmountDisplay) -
+      (Number(simulateAmountDisplay) * Number(userSlippage * atomic)) / (100 * Number(atomic));
     return result;
   } catch (error) {
     console.log({ error });
-    return '0';
+    return 0;
   }
 };
 
@@ -111,7 +112,10 @@ export async function handleSimulateSwap(query: {
     return { amount, displayAmount };
   }
   const { amount } = await simulateSwap(query);
-  return { amount, displayAmount: amount };
+  return {
+    amount,
+    displayAmount: toDisplay(amount, getTokenOnOraichain(query.toInfo.coinGeckoId)?.decimals)
+  };
 }
 
 export function filterNonPoolEvmTokens(

--- a/src/rest/api.ts
+++ b/src/rest/api.ts
@@ -526,7 +526,7 @@ async function simulateSwapEvm(query: {
       // to display to reset the simulate amount to correct display type (swap simulate from -> same chain id to, so we use same chain id toToken decimals)
       // then toAmount with actual toInfo decimals so that it has the same decimals as other tokens displayed
       amount: simulateAmount,
-      displayAmount: toDisplay(simulateAmount, toInfo.decimals) // get the final out amount, which is the token out amount we want
+      displayAmount: toDisplay(simulateAmount, toTokenInfoOnSameChainId.decimals) // get the final out amount, which is the token out amount we want
     };
   } catch (ex) {
     console.log('error simulating evm: ', ex);

--- a/src/rest/api.ts
+++ b/src/rest/api.ts
@@ -39,6 +39,7 @@ import { IBCInfo } from 'types/ibc';
 import { PairInfoExtend, TokenInfo } from 'types/token';
 import { IUniswapV2Router02__factory } from 'types/typechain-types';
 import { ethers } from 'ethers';
+import { SimulateResponse } from 'pages/UniversalSwap/helpers';
 
 export enum Type {
   'TRANSFER' = 'Transfer',
@@ -498,13 +499,18 @@ export function getEvmSwapRoute(
   return undefined;
 }
 
-async function simulateSwapEvm(query: { fromInfo: TokenItemType; toInfo: TokenItemType; amount: string }) {
+async function simulateSwapEvm(query: {
+  fromInfo: TokenItemType;
+  toInfo: TokenItemType;
+  amount: string;
+}): Promise<SimulateResponse> {
   const { amount, fromInfo, toInfo } = query;
 
   // check for universal-swap 2 tokens that have same coingeckoId, should return simulate data with average ratio 1-1.
   if (fromInfo.coinGeckoId === toInfo.coinGeckoId) {
     return {
-      amount
+      amount,
+      displayAmount: toDisplay(amount, toInfo.decimals)
     };
   }
   try {
@@ -520,7 +526,7 @@ async function simulateSwapEvm(query: { fromInfo: TokenItemType; toInfo: TokenIt
       // to display to reset the simulate amount to correct display type (swap simulate from -> same chain id to, so we use same chain id toToken decimals)
       // then toAmount with actual toInfo decimals so that it has the same decimals as other tokens displayed
       amount: simulateAmount,
-      displayAmount: toAmount(toDisplay(simulateAmount, toTokenInfoOnSameChainId.decimals), toInfo.decimals).toString() // get the final out amount, which is the token out amount we want
+      displayAmount: toDisplay(simulateAmount, toInfo.decimals) // get the final out amount, which is the token out amount we want
     };
   } catch (ex) {
     console.log('error simulating evm: ', ex);

--- a/src/tests/universal-swap.spec.ts
+++ b/src/tests/universal-swap.spec.ts
@@ -224,7 +224,7 @@ describe('universal-swap', () => {
     const simulateSwapSpy = jest.spyOn(restApi, 'simulateSwap');
     const simulateSwapEvmSpy = jest.spyOn(restApi, 'simulateSwapEvm');
     simulateSwapSpy.mockResolvedValue({ amount: '1' });
-    simulateSwapEvmSpy.mockResolvedValue({ amount: '2' });
+    simulateSwapEvmSpy.mockResolvedValue({ amount: '2', displayAmount: 2 });
     const isSupportedNoPoolSwapEvmSpy = jest.spyOn(restApi, 'isSupportedNoPoolSwapEvm');
     const isEvmSwappableSpy = jest.spyOn(restApi, 'isEvmSwappable');
     isSupportedNoPoolSwapEvmSpy.mockReturnValue(isSupportedNoPoolSwapEvmRes);
@@ -289,9 +289,9 @@ describe('universal-swap', () => {
 
   it('calculate minimum', async () => {
     const calculate = calculateMinimum('36363993', 2.5);
-    expect(calculate).toBe(35454894n);
+    expect(calculate).toBe(35454893.175);
     const errorCase = calculateMinimum(undefined, 2.5);
-    expect(errorCase).toEqual('0');
+    expect(errorCase).toEqual(0);
   });
 
   describe('generate msgs contract for swap action', () => {


### PR DESCRIPTION
- The bug affects the UX of the universal swap page.
- When user swaps tokens from Oraichain to BSC or Ethereum, the simulate display amount & minimum receive amount is always 0.

- This PR fixes the bug by removing all the decimals of the simulate display amount, making it a floating number ready to be displayed. The universal swap UI component does not have to care about converting the amount to the correct decimal anymore
