### PR TITLE
fix: remove comma in menu link

### DIFF
--- a/src/layouts/MenuV3.tsx
+++ b/src/layouts/MenuV3.tsx
@@ -90,7 +90,8 @@ const Menu: React.FC = React.memo(() => {
 
   const menuList = (
     <div className={classNames(styles.menu_list)}>
-      {renderLink('/universalswap', 'SWAP', setLink)},{renderLink('/bridge', 'BRIDGE', setLink)},
+      {renderLink('/universalswap', 'SWAP', setLink)}
+      {renderLink('/bridge', 'BRIDGE', setLink)}
       {renderLink('/pools', 'POOLS', setLink)}
       {renderLink('https://orderbook.oraidex.io', 'ORDER BOOK', () => {}, true)}
       {renderLink('coming-soon', 'FUTURES', () => {}, true)}


### PR DESCRIPTION
What is purpose of the changes?

 - Remove redundant comma in menu link