### PR TITLE
update: remove optimisctic update volume pool after provide/withdraw lp

### DIFF
--- a/src/pages/Pools/PoolDetailV3.tsx
+++ b/src/pages/Pools/PoolDetailV3.tsx
@@ -15,7 +15,6 @@ import styles from './PoolDetailV3.module.scss';
 import { Earning } from './components/Earning';
 import { MyPoolInfo } from './components/MyPoolInfo/MyPoolInfo';
 import { OverviewPool } from './components/OverviewPool';
-import { recalculateApr } from './helpers';
 import { fetchLpPoolsFromContract, useGetPoolDetail, useGetPools } from './hookV3';
 import { useGetPairInfo } from './hooks/useGetPairInfo';
 
@@ -56,17 +55,9 @@ const PoolDetailV3: React.FC = () => {
       const queryKey = ['pool-detail', poolUrl];
       queryClient.setQueryData(queryKey, (oldPoolDetail: PoolInfoResponse) => {
         const updatedTotalLiquidity = oldPoolDetail.totalLiquidity + amountLpInUsdt;
-        const updatedVolume24h = +oldPoolDetail.volume24Hour + Math.trunc(Math.abs(amountLpInUsdt));
-        const updatedApr = recalculateApr({
-          current24hChange: +oldPoolDetail.volume24hChange,
-          currentVolume: +oldPoolDetail.volume24Hour,
-          amountUsdt: amountLpInUsdt
-        });
         return {
           ...oldPoolDetail,
-          totalLiquidity: updatedTotalLiquidity,
-          volume24Hour: updatedVolume24h.toString(),
-          volume24hChange: updatedApr.toString()
+          totalLiquidity: updatedTotalLiquidity
         };
       });
     },

--- a/src/pages/Pools/helpers.ts
+++ b/src/pages/Pools/helpers.ts
@@ -10,7 +10,7 @@ import {
   PairInfo
 } from '@oraichain/oraidex-contracts-sdk';
 import { assetInfoMap, tokenMap, oraichainTokens } from 'config/bridgeTokens';
-import { ORAI, ORAIXOCH_INFO, ORAIX_INFO, ORAI_INFO, SEC_PER_YEAR, STABLE_DENOM } from '@oraichain/oraidex-common';
+import { ORAI, ORAIXOCH_INFO, SEC_PER_YEAR, STABLE_DENOM } from '@oraichain/oraidex-common';
 import { network } from 'config/networks';
 import { CoinGeckoPrices } from 'hooks/useCoingecko';
 import isEqual from 'lodash/isEqual';
@@ -426,32 +426,6 @@ export const estimateShare = ({
     Number((quoteAmount * totalShare) / totalQuoteAmount)
   );
   return share;
-};
-
-/**
- * Re-calculate APR after provide/withdraw LP to optimistic update UI.
- * @param currentApr
- * @param currentVolume
- * @param amountUsdt - amount volume to add
- * @returns new APR
- */
-export const recalculateApr = ({
-  current24hChange,
-  currentVolume,
-  amountUsdt
-}: {
-  current24hChange: number;
-  currentVolume: number;
-  amountUsdt: number;
-}) => {
-  // guard to avoid crash
-  if (currentVolume === 0) return current24hChange;
-  const volume24hAgo = currentVolume / (current24hChange + 1);
-
-  // guard to avoid crash
-  if (currentVolume === volume24hAgo) return current24hChange;
-  const newApr = current24hChange * (1 + amountUsdt / (currentVolume - volume24hAgo));
-  return newApr;
 };
 
 export {

--- a/src/tests/pool.spec.ts
+++ b/src/tests/pool.spec.ts
@@ -19,7 +19,6 @@ import {
   fetchPoolListAndOraiPrice,
   formatDisplayUsdt,
   PairInfoData,
-  recalculateApr,
   toFixedIfNecessary,
   toPairDetails
 } from 'pages/Pools/helpers';
@@ -548,32 +547,5 @@ describe('pool', () => {
 
     // assertion
     expect(result).toEqual(expectedResult);
-  });
-
-  describe('recalculateApr', () => {
-    it.each([
-      [0.1, 1000, 100, 0.20999999999999988],
-      [0.2, 500, 50, 0.32000000000000006],
-      [0.5, 2000, 150, 0.6125]
-    ])('calculates new APR correctly', (current24hChange, currentVolume, amountUsdt, expectedApr) => {
-      const newApr = recalculateApr({ current24hChange, currentVolume, amountUsdt });
-      expect(newApr).toBeCloseTo(expectedApr, 6);
-    });
-
-    it('handles edge case when currentVolume is 0 should return current24hChange value', () => {
-      const current24hChange = 0.1;
-      const currentVolume = 0;
-      const amountUsdt = 100;
-      const newApr = recalculateApr({ current24hChange, currentVolume, amountUsdt });
-      expect(newApr).toBe(current24hChange);
-    });
-
-    it('handles edge case when current24hChange is 0', () => {
-      const current24hChange = 0;
-      const currentVolume = 1000;
-      const amountUsdt = 100;
-      const newApr = recalculateApr({ current24hChange, currentVolume, amountUsdt });
-      expect(newApr).toBe(0);
-    });
   });
 });


### PR DESCRIPTION
What is purpose of the changes?

 - Remove optimistic update volume pool after provide/withdraw lp, we dont accumulate volume for these ops anymore.