### PR TITLE
hotfix: correct simulate averate for some special cases

### DIFF
--- a/src/pages/UniversalSwap/SwapV3/hooks/useSimulate.ts
+++ b/src/pages/UniversalSwap/SwapV3/hooks/useSimulate.ts
@@ -1,9 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
 import { TokenItemType } from '@oraichain/oraidex-common';
+import { OraiswapRouterReadOnlyInterface } from '@oraichain/oraidex-contracts-sdk';
+import { handleSimulateSwap } from '@oraichain/oraidex-universal-swap';
+import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { TokenInfo } from 'types/token';
-import { SimulateResponse, handleSimulateSwap } from '@oraichain/oraidex-universal-swap';
-import { OraiswapRouterReadOnlyInterface } from '@oraichain/oraidex-contracts-sdk';
 
 /**
  * Simulate ratio between fromToken & toToken
@@ -40,7 +40,9 @@ export const useSimulate = (
   );
 
   useEffect(() => {
-    setSwapAmount([fromAmountToken, Number(simulateData?.displayAmount)]);
+    // initAmount used for simulate averate ratio
+    const fromAmount = initAmount ?? fromAmountToken;
+    setSwapAmount([fromAmount, Number(simulateData?.displayAmount)]);
   }, [simulateData, fromAmountToken, fromTokenInfoData, toTokenInfoData]);
 
   return { simulateData, fromAmountToken, toAmountToken, setSwapAmount };

--- a/src/pages/UniversalSwap/SwapV3/index.tsx
+++ b/src/pages/UniversalSwap/SwapV3/index.tsx
@@ -188,7 +188,13 @@ const SwapComponent: React.FC<{
   );
 
   // TODO: use this constant so we can temporary simulate for all pair (specifically AIRI/USDC), update later after migrate contract
-  const INIT_AMOUNT = 1000;
+  const isFromAiriToUsdc = originalFromToken.coinGeckoId === 'airight' && originalToToken.coinGeckoId === 'usd-coin';
+  const isFromUsdc = originalFromToken.coinGeckoId === 'usd-coin';
+
+  const INIT_SIMULATE_AIRI_TO_USDC = 1000;
+  const INIT_SIMULATE_FROM_USDC = 10;
+  const INIT_AMOUNT = isFromAiriToUsdc ? INIT_SIMULATE_AIRI_TO_USDC : isFromUsdc ? INIT_SIMULATE_FROM_USDC : 1;
+
   const { simulateData: averageRatio } = useSimulate(
     'simulate-average-data',
     fromTokenInfoData,


### PR DESCRIPTION
What is purpose of the changes?

 -  Correct simulate averate for some special swap cases: AIRI-> USDC, USDC -> other