### PR TITLE
fix: hardcode simulate with to token is weth

### DIFF
--- a/src/pages/UniversalSwap/SwapV3/index.tsx
+++ b/src/pages/UniversalSwap/SwapV3/index.tsx
@@ -194,17 +194,16 @@ const SwapComponent: React.FC<{
   // TODO: use this constant so we can temporary simulate for all pair (specifically AIRI/USDC, ORAIX/USDC), update later after migrate contract
   const isFromAiriToUsdc = originalFromToken.coinGeckoId === 'airight' && originalToToken.coinGeckoId === 'usd-coin';
   const isFromOraixToUsdc = originalFromToken.coinGeckoId === 'oraidex' && originalToToken.coinGeckoId === 'usd-coin';
-  const isFromOraiToWeth =
-    originalFromToken.coinGeckoId === 'oraichain-token' && originalToToken.coinGeckoId === 'weth';
+  const isToWETH = originalToToken.coinGeckoId === 'weth';
 
   const isFromUsdc = originalFromToken.coinGeckoId === 'usd-coin';
 
   const INIT_SIMULATE_THOUNDSAND_AMOUNT = 1000;
   const INIT_SIMULATE_TEN_AMOUNT = 10;
   const INIT_AMOUNT =
-    isFromAiriToUsdc || isFromOraixToUsdc
+    isFromAiriToUsdc || isFromOraixToUsdc || isToWETH
       ? INIT_SIMULATE_THOUNDSAND_AMOUNT
-      : isFromUsdc || isFromOraiToWeth
+      : isFromUsdc
       ? INIT_SIMULATE_TEN_AMOUNT
       : 1;
 
@@ -240,12 +239,12 @@ const SwapComponent: React.FC<{
   const isSimulateDataDisplay = simulateData && simulateData.displayAmount;
   const minimumReceive = isAverageRatio
     ? calculateMinReceive(
-      // @ts-ignore
-      Math.trunc(new BigDecimal(averageRatio.amount) / INIT_AMOUNT).toString(),
-      fromAmountTokenBalance.toString(),
-      userSlippage,
-      originalFromToken.decimals
-    )
+        // @ts-ignore
+        Math.trunc(new BigDecimal(averageRatio.amount) / INIT_AMOUNT).toString(),
+        fromAmountTokenBalance.toString(),
+        userSlippage,
+        originalFromToken.decimals
+      )
     : '0';
   const isWarningSlippage = +minimumReceive > +simulateData?.amount;
   const simulateDisplayAmount = simulateData && simulateData.displayAmount ? simulateData.displayAmount : 0;
@@ -256,8 +255,8 @@ const SwapComponent: React.FC<{
 
   const minimumReceiveDisplay = isSimulateDataDisplay
     ? new BigDecimal(
-      simulateDisplayAmount - (simulateDisplayAmount * userSlippage) / 100 - relayerFee - bridgeTokenFee
-    ).toNumber()
+        simulateDisplayAmount - (simulateDisplayAmount * userSlippage) / 100 - relayerFee - bridgeTokenFee
+      ).toNumber()
     : 0;
 
   const expectOutputDisplay = isSimulateDataDisplay
@@ -336,7 +335,7 @@ const SwapComponent: React.FC<{
       console.log({ error });
       handleErrorTransaction(error, {
         tokenName: originalToToken.name,
-        chainName: originalToToken.chainId,
+        chainName: originalToToken.chainId
       });
     } finally {
       setSwapLoading(false);
@@ -452,8 +451,9 @@ const SwapComponent: React.FC<{
               />
 
               <div className={cx('ratio')}>
-                {`1 ${originalFromToken.name} ≈ ${averageRatio ? Number((averageRatio.displayAmount / INIT_AMOUNT).toFixed(6)) : '0'
-                  } ${originalToToken.name}`}
+                {`1 ${originalFromToken.name} ≈ ${
+                  averageRatio ? Number((averageRatio.displayAmount / INIT_AMOUNT).toFixed(6)) : '0'
+                } ${originalToToken.name}`}
               </div>
             </div>
           </div>


### PR DESCRIPTION
What is purpose of the changes?

 - Hardcode simulate for universal swap with to token is wETH