### PR TITLE
fix: ignore network error & not throw error when connect evm failed

### DIFF
--- a/src/hooks/useMetamask.ts
+++ b/src/hooks/useMetamask.ts
@@ -64,7 +64,6 @@ export function useEagerConnect() {
       }
     } catch (error) {
       console.log({ errorConnectMetmask: error });
-      throw new Error(error?.message ?? JSON.stringify(error));
     }
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,7 @@ if (process.env.REACT_APP_SENTRY_ENVIRONMENT === 'production') {
       /^chrome-extension:\/\//i,
       /^moz-extension:\/\//i
     ],
-    ignoreErrors: ['Request rejected', 'Failed to fetch', 'Load failed', 'User rejected the request'],
+    ignoreErrors: ['Request rejected', 'Failed to fetch', 'Load failed', 'User rejected the request', 'Network Error'],
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production


### PR DESCRIPTION
What is purpose of the changes?

 - Ignore network error for Sentry
 - Handle error when connect metmask failed