### PR TITLE
fix: handle error is undefined with typeof string

### DIFF
--- a/src/libs/metamask.ts
+++ b/src/libs/metamask.ts
@@ -53,6 +53,7 @@ export default class Metamask extends EvmWallet {
         method: 'eth_requestAccounts',
         params: []
       });
+      if (address === 'undefined') return '';
       return address;
     }
   }


### PR DESCRIPTION
What is purpose of the changes?

 - Check eth_requestAccounts address  is 'undefined' as string. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for Ethereum account requests to prevent issues with undefined addresses.
	- Added a safeguard to ensure that invalid addresses do not cause unintended behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->