### PR TITLE
pumb version 1.1.12 fix swap 0x38 -> oraichain

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@oraichain/orai-bitcoin": "2.0.0",
     "@oraichain/oraidex-common-ui": "1.0.11",
     "@oraichain/oraidex-contracts-sdk": "1.0.51-beta.3",
-    "@oraichain/oraidex-universal-swap": "1.1.10",
+    "@oraichain/oraidex-universal-swap": "1.1.12",
     "@reduxjs/toolkit": "^1.9.3",
     "@sentry/react": "^7.47.1",
     "@tanstack/react-query": "^4.32.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4421,10 +4421,10 @@
   resolved "https://registry.yarnpkg.com/@oraichain/oraidex-contracts-sdk/-/oraidex-contracts-sdk-1.0.45.tgz#42dae0fdd9e005f920ba305b987009f791acc365"
   integrity sha512-/nYztdxEX5LQM4DMJQmi9HvZrBVoY3nLAmYqSKZGZ0U1h1SxU7O/o22R3/pQwB+sAJdcibaI8ygC0ov7jC8paA==
 
-"@oraichain/oraidex-universal-swap@1.1.10":
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/@oraichain/oraidex-universal-swap/-/oraidex-universal-swap-1.1.10.tgz#0fb6bf567d7b36b92f50ae433949ddfb8df3eb7a"
-  integrity sha512-q1q2f6F3mVUwyNxOgn+6QQaBbNubAuiD9kD4xnNj9WAgvZqIjUexMF8UWSSC37992W68eJCvkMHkvofTKMz4Ig==
+"@oraichain/oraidex-universal-swap@1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@oraichain/oraidex-universal-swap/-/oraidex-universal-swap-1.1.12.tgz#0cd1cc9302dc6fb6d866db00fdd02764f05e827a"
+  integrity sha512-03R3qNLv/QnwQGfcg5EaJC2nTlF1Er/VzyrwbLgrHsnIXYewJ9dH++78KNQnETy2iwKzMlRLSFFeGaWkdxp1sw==
   dependencies:
     "@oraichain/common" "^1.0.3"
     "@oraichain/oraidex-common" "^1.1.21"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the dependency version for `@oraichain/oraidex-universal-swap` from `1.1.10` to `1.1.12`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->