### PR TITLE
update warning limit modal swap warning

### DIFF
--- a/src/pages/UniversalSwap/Swap/index.tsx
+++ b/src/pages/UniversalSwap/Swap/index.tsx
@@ -830,7 +830,7 @@ const SwapComponent: React.FC<{
               <button
                 className={cx('swap-btn', `${disabledSwapBtn ? 'disable' : ''}`)}
                 onClick={() => {
-                  if (impactWarning > 10) return setOpenSwapWarning(true);
+                  if (impactWarning > 5) return setOpenSwapWarning(true);
                   handleSubmit();
                 }}
                 disabled={disabledSwapBtn}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Adjusted the threshold for the Swap Warning Modal, allowing users to proceed with swaps that have a lower price impact warning (now greater than 5) without additional confirmation.
  
- **Style**
	- Minor adjustments to comments and formatting for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->